### PR TITLE
PDTs and Aux types

### DIFF
--- a/src/main/scala/Abstraction.scala
+++ b/src/main/scala/Abstraction.scala
@@ -3,6 +3,10 @@ package help
 /*
  * A type bag, holding many unfilled type references
  */
-abstract class Abstraction {
+trait Abstraction[A] {
   type Member
+}
+
+object Abstraction {
+  type Aux[A, M] = Abstraction[A] { type Member = M }
 }

--- a/src/main/scala/Instance.scala
+++ b/src/main/scala/Instance.scala
@@ -3,6 +3,12 @@ package help
 /*
  * A subtype of Abstraction with all the members filled
  */
-class Instance extends Abstraction {
-  type Member = String
+class Instance
+
+object Instance {
+
+  implicit def instanceAbstraction: Abstraction.Aux[Instance, String] = new Abstraction[Instance] {
+    override final type Member = String
+  }
+
 }

--- a/src/main/scala/Logic.scala
+++ b/src/main/scala/Logic.scala
@@ -3,19 +3,25 @@ package help
 /*
  * A case class capable of storing a reference to some `Member`, where type alignment is enforced by consumers
  */
-case class Data[I <: Abstraction](value: I#Member)
-// Importantly, the following will not compile:
-//     case class Data[I <: Abstraction](I: I)(value: I.Member)
-// and this one can never be satisfied:
-//   class Container[I <: Abstraction](I: I) {
-//     case class Data(value: I.Member)
-//   }
+case class Data[A, M](value: M)(implicit abstraction: Abstraction.Aux[A, M])
+case class Data2[A, M](a: A, value: M)(implicit abstraction: Abstraction.Aux[A, M])
+class Container[A, M](a: A)(implicit abstraction: Abstraction.Aux[A, M]) {
+  case class Data(value: M)
+}
 
 /*
  * A class defining a collection of functions that all share the same `Abstraction`, able to accept parameterized
  * case classes, as well as return types constrained by the top-level type parameter (`I`)
  */
-abstract class Logic[I <: Abstraction] {
-  def build(value: I#Member): Data[I]
-  def func(data: Data[I]): I#Member
+abstract class Logic[A] {
+  type Member
+
+  def abstraction: Abstraction.Aux[A, Member]
+
+  def build(value: Member): Data[A, Member]
+  def func(data: Data[A, Member]): Member
+}
+
+object Logic {
+  type Aux[A, M] = Logic[A] { type Member = M }
 }

--- a/src/main/scala/Main.scala
+++ b/src/main/scala/Main.scala
@@ -1,9 +1,15 @@
 package help
 
 object Main extends App {
-  def createLogic = new Logic[Instance] {
-    def build(value: String): Data[Instance] = Data[Instance](value)
-    def func(data: Data[Instance]): String = data.value
+  def createLogic: Logic.Aux[Instance, String] = new Logic[Instance] {
+    override final type Member = String
+
+    override def abstraction: Abstraction.Aux[Instance, String] = new Abstraction[Instance] {
+      override final type Member = String
+    }
+
+    override def build(value: String): Data[Instance, String] = Data[Instance, String](value)
+    override def func(data: Data[Instance, String]): String = data.value
   }
 
   val logic1 = createLogic

--- a/src/main/scala/Main.scala
+++ b/src/main/scala/Main.scala
@@ -4,9 +4,7 @@ object Main extends App {
   def createLogic: Logic.Aux[Instance, String] = new Logic[Instance] {
     override final type Member = String
 
-    override def abstraction: Abstraction.Aux[Instance, String] = new Abstraction[Instance] {
-      override final type Member = String
-    }
+    override def abstraction: Abstraction.Aux[Instance, String] = implicitly
 
     override def build(value: String): Data[Instance, String] = Data[Instance, String](value)
     override def func(data: Data[Instance, String]): String = data.value


### PR DESCRIPTION
An example of what I talked about in the Scala discord.

To extend this to more type members, one can create aliases for only the members needed under a specific structure or domain. For example
```scala
trait Abstraction[A] {
  type Member1
  type Member2
}
```
```scala
case class Data1[A, M](m: M)(implicit abs: Data1.AbstractionAux[A, M])
object Data1 { type AbstractionAux[A, M] = Abstraction[A] { type Member1 = M } }

case class Data2[A, M](m: M)(implicit abs: Data2.AbstractionAux[A, M])
object Data2 { type AbstractionAux[A, M] = Abstraction[A] { type Member2 = M } }

case class Data3[A, M, N](m: M, n: N)(implicit abs: Data3.AbstractionAux[A, M, N])
object Data3 { type AbstractionAux[A, M, N] = Abstraction[A] { type Member1 = M ; type Member2 = N } }
```

`Logic` could either be `Logic[A, M]` or `Logic[A] { type Member }`.

If you need to store `Data1[???, M]`s, i.e. Datas with any possible abstraction type, but the same value, use an existential helper:
```scala
sealed trait ArbitraryData1[M] {
  type First
  val second: M
  val evidence: Abstraction[First, M]
}
object ArbitraryData1 {
  // apply and unapply
}
```